### PR TITLE
fix: Update extension.ts to ignore command: section

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -312,8 +312,12 @@ function transformKeyValueLists(obj: any): void {
 		if (obj.hasOwnProperty(key)) {
 			const value = obj[key];
 			
-			// If value is an array of strings that contain '=', transform it
-			if (Array.isArray(value) && value.length > 0) {
+		   // Skip transforming the 'command' field; always keep as array of strings
+		   if (key === 'command') {
+			   continue;
+		   }
+		   // If value is an array of strings that contain '=', transform it
+		   if (Array.isArray(value) && value.length > 0) {
 				const keyValueMap: { [key: string]: string } = {};
 				let allAreKeyValuePairs = true;
 				


### PR DESCRIPTION
According to the docs the command: section is similar to the Dockerfile exec form which is a single string or an array of strings. https://docs.docker.com/reference/compose-file/services/#command

This change simply adds a guard clause to ensure that the command: section is ignored.

This resolves #1 but may be too broad of a fix.