### PR TITLE
ci: bump CI Node.js version to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "npm"
 
       - name: Install Dependencies


### PR DESCRIPTION
## Summary
- `@vscode/test-electron` 3.0.0 (#17) declares `engines.node: >=22`. Bump the CI runner from Node 20 to 22 to match, and avoid relying on the unenforced engine warning.

## Test plan
- [ ] CI passes on Node 22.