### PR TITLE
fix: "BUG: Repeated formatting adds extra lines between comment and section" Issue: #21

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -300,6 +300,22 @@ export class DockerComposeSorter {
     return map;
   }
 
+  private static lastValueHasComment(value: any): boolean {
+    if (!value) {
+      return false;
+    }
+    if (value.comment) {
+      return true;
+    }
+    if (yaml.isMap(value) && value.items.length > 0) {
+      return DockerComposeSorter.lastValueHasComment(value.items[value.items.length - 1].value);
+    }
+    if (yaml.isSeq(value) && value.items.length > 0) {
+      return DockerComposeSorter.lastValueHasComment(value.items[value.items.length - 1]);
+    }
+    return false;
+  }
+
   private static applySpacing(contents: yaml.YAMLMap, config: SorterConfig): void {
     const resetSpacing = (node: any) => {
       if (node && node.key) {
@@ -313,7 +329,11 @@ export class DockerComposeSorter {
     if (config.addBlankLinesTopLevel) {
       contents.items.forEach((item, index) => {
         if (index > 0 && yaml.isScalar(item.key)) {
-          item.key.spaceBefore = true;
+          // Don't add spaceBefore if the previous item ends with a trailing
+          // the yaml stringifier already inserts a blank line there
+          if (!DockerComposeSorter.lastValueHasComment(contents.items[index - 1].value)) {
+            item.key.spaceBefore = true;
+          }
         }
       });
     }
@@ -324,7 +344,9 @@ export class DockerComposeSorter {
       if (services && yaml.isMap(services)) {
         services.items.forEach((item, index) => {
           if (index > 0 && yaml.isScalar(item.key)) {
-            item.key.spaceBefore = true;
+            if (!DockerComposeSorter.lastValueHasComment(services.items[index - 1].value)) {
+              item.key.spaceBefore = true;
+            }
           }
         });
       }

--- a/src/test/suite/sorter.test.ts
+++ b/src/test/suite/sorter.test.ts
@@ -470,4 +470,34 @@ version: "3.8"
     const twice = DockerComposeSorter.sort(once, cleanConfig());
     expect(twice).to.equal(once);
   });
+
+  test("Robustness: Trailing comment does not add extra blank lines on each format run", () => {
+    const input = `services:
+  nginx:
+    image: nginx
+    networks:
+      - nginx-net
+    # Comment
+
+networks:
+  nginx-net:
+    name: nginx-net
+`;
+    const once = DockerComposeSorter.sort(input, cleanConfig());
+    const twice = DockerComposeSorter.sort(once, cleanConfig());
+
+    // Exactly one blank line between the comment and the next section
+    const lines = once.split("\n");
+    const commentIdx = lines.findIndex((l) => l.includes("# Comment"));
+    expect(commentIdx).to.be.greaterThan(-1);
+    const netIdx = lines.findIndex((l) => l.startsWith("networks:"));
+    expect(netIdx).to.be.greaterThan(commentIdx);
+    // There should be exactly one blank line (one empty line) between comment and networks
+    const betweenLines = lines.slice(commentIdx + 1, netIdx);
+    expect(betweenLines).to.have.lengthOf(1);
+    expect(betweenLines[0]).to.equal("");
+
+    // Second format should produce identical output
+    expect(twice).to.equal(once);
+  });
 });


### PR DESCRIPTION
Fix for: [BUG: Repeated formatting adds extra lines between comment and section](https://github.com/SashaBusinaro/yaml-compose-sorter/issues/21)

Root cause: In applySpacing, spaceBefore = true was unconditionally set on every non-first top-level/service key. The yaml library's stringifier already inserts a blank line after a trailing comment (the \n at the end of the comment text combines with the map item separator to form a blank line). So setting spaceBefore = true on top of that produced a double blank line. On each subsequent format, the extra blank line was absorbed into the comment text as an additional trailing \n, causing the gap to grow by one blank line per format run.

Fix: Added lastValueHasComment() (lines 303–321) that walks the last-leaf path of a node tree to detect trailing comments. In applySpacing, before setting spaceBefore = true, we now check if the previous item's value tree ends with a trailing comment. If so, we skip setting spaceBefore since the yaml library already inserts the blank line there. This applies to both top-level and service-level spacing (lines 338, 351).