### PR TITLE
fix: stop blank lines stacking between trailing comments and sections (#21)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -314,6 +314,7 @@ export class DockerComposeSorter {
       contents.items.forEach((item, index) => {
         if (index > 0 && yaml.isScalar(item.key)) {
           item.key.spaceBefore = true;
+          this.stripBoundaryCommentBlanks(contents.items[index - 1].value);
         }
       });
     }
@@ -325,9 +326,46 @@ export class DockerComposeSorter {
         services.items.forEach((item, index) => {
           if (index > 0 && yaml.isScalar(item.key)) {
             item.key.spaceBefore = true;
+            this.stripBoundaryCommentBlanks(services.items[index - 1].value);
           }
         });
       }
+    }
+  }
+
+  /**
+   * The blank line that separates a block from the following sibling is owned
+   * by that sibling's `spaceBefore` flag. A trailing comment that closes the
+   * preceding block can *also* encode those blank lines as trailing newlines in
+   * its `comment` string. Left untouched they stack with `spaceBefore` and grow
+   * by one on every format run (issue #21), breaking idempotency.
+   *
+   * Strip the trailing blank-line newlines from the comment that renders right
+   * before the next sibling: the outermost trailing comment along the rightmost
+   * spine of `prevValue`. Inner comments and `commentBefore` are left alone, so
+   * blank lines *inside* a block are preserved.
+   */
+  private static stripBoundaryCommentBlanks(prevValue: unknown): void {
+    let node = prevValue as { comment?: unknown; items?: unknown[] } | null | undefined;
+
+    while (node) {
+      if (typeof node.comment === "string") {
+        // Outermost trailing comment found: normalize it only if it carries
+        // boundary blank lines, then stop (deeper comments stay intra-block).
+        node.comment = node.comment.replace(/\n+$/, "");
+        return;
+      }
+
+      // Descend along the rightmost spine (last child) toward the boundary.
+      if (!yaml.isMap(node) && !yaml.isSeq(node)) {
+        return;
+      }
+      const items = node.items;
+      if (!items || items.length === 0) {
+        return;
+      }
+      const last = items[items.length - 1];
+      node = (yaml.isPair(last) ? last.value : last) as typeof node;
     }
   }
 }

--- a/src/test/suite/sorter.test.ts
+++ b/src/test/suite/sorter.test.ts
@@ -470,4 +470,106 @@ version: "3.8"
     const twice = DockerComposeSorter.sort(once, cleanConfig());
     expect(twice).to.equal(once);
   });
+
+  /*
+   * ==========================================
+   * 8. Idempotency with trailing comments (issue #21)
+   * ==========================================
+   *
+   * A comment that closes a block absorbs the blank line separating it from the
+   * next section as trailing newlines in its `comment` string. That blank line
+   * is also owned by the next key's `spaceBefore`, so without normalization the
+   * two stack and a new blank line is added on every format run.
+   */
+  test("Idempotency: trailing comment before a top-level section (issue #21)", () => {
+    const input = `services:
+  nginx:
+    image: nginx
+    networks:
+      - nginx-net
+    # Comment
+
+networks:
+  nginx-net:
+    name: nginx-net
+`;
+    const expected = `services:
+  nginx:
+    image: nginx
+    networks:
+      - nginx-net
+    # Comment
+
+networks:
+  nginx-net:
+    name: nginx-net
+`;
+    const once = DockerComposeSorter.sort(input, cleanConfig());
+    // Exactly one blank line between the comment and the next section.
+    expect(once).to.equal(expected);
+
+    // Re-running must not add further blank lines.
+    let current = once;
+    for (let i = 0; i < 4; i++) {
+      current = DockerComposeSorter.sort(current, cleanConfig());
+      expect(current, `run ${i + 2} changed the output`).to.equal(once);
+    }
+  });
+
+  test("Idempotency: trailing comment between two services", () => {
+    const input = `services:
+  alpha:
+    image: alpha
+    # tail comment
+
+  beta:
+    image: beta
+`;
+    const once = DockerComposeSorter.sort(input, cleanConfig());
+    const twice = DockerComposeSorter.sort(once, cleanConfig());
+    expect(twice).to.equal(once);
+    // Single blank line between the comment and the next service.
+    expect(once).to.contain("# tail comment\n\n  beta:");
+    expect(once).to.not.contain("# tail comment\n\n\n");
+  });
+
+  test("Idempotency: deeply nested trailing comment before a section", () => {
+    const input = `services:
+  nginx:
+    image: nginx
+    networks:
+      - nginx-net
+      # deep comment
+
+networks:
+  net: {}
+`;
+    const once = DockerComposeSorter.sort(input, cleanConfig());
+    const twice = DockerComposeSorter.sort(once, cleanConfig());
+    expect(twice).to.equal(once);
+    expect(once).to.contain("# deep comment\n\nnetworks:");
+    expect(once).to.not.contain("# deep comment\n\n\n");
+  });
+
+  test("Idempotency: blank line inside a block (no spaceBefore) is preserved", () => {
+    // The comment closes the `environment` list and is followed by `labels`, a
+    // service key that never receives `spaceBefore` (only top-level keys and
+    // service names do). The blank line is intra-block and must survive
+    // untouched, proving the fix is not over-eager. Keys are already in config
+    // order so sorting does not move them.
+    const input = `services:
+  web:
+    image: nginx
+    environment:
+      - A=1
+      # note
+
+    labels:
+      - x=y
+`;
+    const once = DockerComposeSorter.sort(input, cleanConfig());
+    const twice = DockerComposeSorter.sort(once, cleanConfig());
+    expect(twice).to.equal(once);
+    expect(once).to.contain("# note\n\n    labels:");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #21: repeated formatting kept adding a blank line between a trailing comment and the following top-level section (or service), growing by one on every run.

## Root cause

A comment that closes a block is parsed as that block's trailing `comment`, absorbing the separating blank line as a trailing newline. That same blank line is also owned by the next key's `spaceBefore` flag, so the two stacked and a fresh blank line was appended on every format run, breaking idempotency.

## Fix

Make `spaceBefore` the single source of truth for section spacing: when applying it, strip the trailing blank-line newlines from the comment that closes the previous sibling (the outermost trailing comment along its rightmost spine). `commentBefore` and blank lines inside a block are left untouched.

This keeps the output consistent at exactly one blank line, heals files already bloated by the bug, and still inserts the separator when a comment sits directly above a section.

## Tests

Added regression tests for top-level, service-level and deeply nested trailing comments, plus a guard that intra-block blank lines survive. Full suite is green (31 passing), lint and Prettier clean.

## Credit

Thanks to @jadebi for the report and for independently confirming the root cause in #22.

Closes #21
