### PR TITLE
build: align @types/vscode with engines.vscode to unblock publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # @types/vscode must track engines.vscode (the minimum supported VS Code
+      # version), never the latest release: bumping it above engines.vscode
+      # makes `vsce publish` reject the package.
+      - dependency-name: "@types/vscode"
     groups:
       dev-dependencies:
         dependency-type: development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,9 @@ jobs:
 
       - name: Run Tests
         run: xvfb-run -a npm test
+
+      # Runs the same validation as `vsce publish` (e.g. @types/vscode must not
+      # exceed engines.vscode), so packaging issues surface here instead of only
+      # at release time.
+      - name: Validate packaging
+        run: npx @vscode/vsce package --out /tmp/extension.vsix

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/chai": "^4.3.20",
         "@types/mocha": "^10.0.10",
         "@types/node": "25.x",
-        "@types/vscode": "^1.120.0",
+        "@types/vscode": "^1.101.0",
         "@typescript-eslint/eslint-plugin": "^8.61.0",
         "@typescript-eslint/parser": "^8.31.1",
         "@vscode/test-cli": "^0.0.12",
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.120.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
-      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.101.0.tgz",
+      "integrity": "sha512-ZWf0IWa+NGegdW3iU42AcDTFHWW7fApLdkdnBqwYEtHVIBGbTu0ZNQKP/kX3Ds/uMJXIMQNAojHR4vexCEEz5Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",
     "@types/node": "25.x",
-    "@types/vscode": "^1.120.0",
+    "@types/vscode": "^1.101.0",
     "@typescript-eslint/eslint-plugin": "^8.61.0",
     "@typescript-eslint/parser": "^8.31.1",
     "@vscode/test-cli": "^0.0.12",


### PR DESCRIPTION
## Problem

The v1.0.2 Marketplace publish failed: `vsce publish` rejects the package when `@types/vscode` is newer than `engines.vscode`.

`@types/vscode` was bumped to `^1.120.0` by Dependabot (#15) while `engines.vscode` stayed at `^1.101.0`. The error stayed hidden until now because the previous publish was blocked by the expired `VSCE_PAT`; with the token renewed, the publish step finally ran and surfaced the mismatch.

## Fix

- **Pin `@types/vscode` back to `^1.101.0`** to match the minimum supported VS Code version (keeps broad compatibility; the extension only uses the long-standing formatter API, so raising `engines.vscode` would needlessly drop users on 1.101–1.119).
- **Dependabot `ignore` for `@types/vscode`** so it tracks `engines.vscode` instead of the latest release.
- **`vsce package` validation step in CI** so this class of packaging error surfaces on every PR instead of only at release time.

## Verification

`npx vsce package` now succeeds locally; compile, lint, Prettier and the full test suite (31 passing) are green.

No version bump (`build:` commit): v1.0.2 already contains the user-facing fix. After merge I will publish 1.0.2 to the Marketplace via the `publish.yml` manual dispatch.
